### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://angeliquerf.visualstudio.com/811421d3-1fad-4252-9b28-991de1ece894/94ec931d-ccd7-4b58-b961-01f3d4491613/_apis/work/boardbadge/857d2235-d5d2-4abe-a4d7-2fcfe7331d6a)](https://angeliquerf.visualstudio.com/811421d3-1fad-4252-9b28-991de1ece894/_boards/board/t/94ec931d-ccd7-4b58-b961-01f3d4491613/Microsoft.RequirementCategory)
 # isit422todos


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://angeliquerf.visualstudio.com/811421d3-1fad-4252-9b28-991de1ece894/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.